### PR TITLE
Update simple-assembler-interpreter-2: hasMissingEnd

### DIFF
--- a/simple-assembler-interpreter-2.js
+++ b/simple-assembler-interpreter-2.js
@@ -10,11 +10,13 @@ function parsedProgram(programInput) {
                 if (lineWithoutComment) {
                     memory.program.push(lineWithoutComment);
 
-                    if (/^\w+:$/.test(lineWithoutComment)) {
+                    const isFunctionLabel = /^\w+:$/.test(lineWithoutComment);
+                    if (isFunctionLabel) {
                         memory.functions[lineWithoutComment.slice(0, -1)] = memory.program.length - 1;
                     }
 
-                    if (memory.hasMissingEnd && lineWithoutComment == 'end') {
+                    const shouldMarkProgramEndingCorrectly = memory.hasMissingEnd && lineWithoutComment == 'end';
+                    if (shouldMarkProgramEndingCorrectly) {
                         memory.hasMissingEnd = false;
                     }
                 }

--- a/simple-assembler-interpreter-2.js
+++ b/simple-assembler-interpreter-2.js
@@ -14,14 +14,14 @@ function parsedProgram(programInput) {
                         memory.functions[lineWithoutComment.slice(0, -1)] = memory.program.length - 1;
                     }
 
-                    if (!memory.hasMissingEnd && lineWithoutComment == 'end') {
-                        memory.hasMissingEnd = true;
+                    if (memory.hasMissingEnd && lineWithoutComment == 'end') {
+                        memory.hasMissingEnd = false;
                     }
                 }
 
                 return memory;
             },
-            { program: [], functions: {}, hasMissingEnd: false },
+            { program: [], functions: {}, hasMissingEnd: true },
         );
 }
 

--- a/simple-assembler-interpreter-2.js
+++ b/simple-assembler-interpreter-2.js
@@ -13,11 +13,15 @@ function parsedProgram(programInput) {
                     if (/^\w+:$/.test(lineWithoutComment)) {
                         memory.functions[lineWithoutComment.slice(0, -1)] = memory.program.length - 1;
                     }
+
+                    if (!memory.hasMissingEnd && lineWithoutComment == 'end') {
+                        memory.hasMissingEnd = true;
+                    }
                 }
 
                 return memory;
             },
-            { program: [], functions: {} },
+            { program: [], functions: {}, hasMissingEnd: false },
         );
 }
 
@@ -60,9 +64,9 @@ function byMsgFormat(line) {
 }
 
 function assemblerInterpreter(programInput) {
-    const { program, functions } = parsedProgram(programInput);
+    const { program, functions, hasMissingEnd } = parsedProgram(programInput);
 
-    if (!program.includes('end')) return -1;
+    if (hasMissingEnd) return -1;
 
     const programSize = program.length;
 


### PR DESCRIPTION
Removing an instance of `includes` and moving the logic to already existing loop